### PR TITLE
replace javax.util.Pair with Map

### DIFF
--- a/src/main/java/org/mbine/co/archive/CombineArchive.java
+++ b/src/main/java/org/mbine/co/archive/CombineArchive.java
@@ -15,7 +15,6 @@
 
 package org.mbine.co.archive;
 
-import javafx.util.Pair;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
@@ -68,7 +67,7 @@ public class CombineArchive implements ICombineArchive {
 
 	@Override
 	public File writeMasterFile() throws IOException {
-		Pair<String, InputStream> masterFile = getMasterFile();
+		Map.Entry<String, InputStream> masterFile = getMasterFile();
 		Path tmpFile = Files.createTempFile("omex-master-file", "");
 		if (masterFile.getKey() != "" && masterFile.getValue() != null) {
 			InputStream stream = masterFile.getValue();
@@ -221,17 +220,17 @@ public class CombineArchive implements ICombineArchive {
 	}
 
 	@Override
-	public Pair<String, InputStream> getMasterFile() {
+	public Map.Entry<String, InputStream> getMasterFile() {
 		Iterator<ArtifactInfo> iterator = artifactIterator();
 		boolean foundMasterFile = false;
-		Pair<String, InputStream> tmp = new Pair<>("", null);
+		Map.Entry<String, InputStream> tmp = new AbstractMap.SimpleEntry<>("", null);
 		while (!foundMasterFile && iterator.hasNext()) {
 			ArtifactInfo artifactInfo = iterator.next();
 			foundMasterFile = artifactInfo.isMaster();
 			if (foundMasterFile) {
 				String format = artifactInfo.getFormat();
 				InputStream stream = readArtifact(artifactInfo);
-				tmp = new Pair<>(format, stream);
+				tmp = new AbstractMap.SimpleEntry<>(format, stream);
 			}
 		}
 		return tmp;

--- a/src/main/java/org/mbine/co/archive/ICombineArchive.java
+++ b/src/main/java/org/mbine/co/archive/ICombineArchive.java
@@ -15,14 +15,13 @@
 
 package org.mbine.co.archive;
 
-import javafx.util.Pair;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.Map;
 
 /**
  * 
@@ -40,7 +39,7 @@ public interface ICombineArchive extends AutoCloseable {
 	 *
 	 * @return A pair of a string as the format and an InputStream object as the content of the master file
 	 */
-	Pair<String, InputStream> getMasterFile();
+	Map.Entry<String, InputStream> getMasterFile();
 
 	/**
 	 * Check the archive has a master or not

--- a/src/test/org/mbine/co/archive/ExtractArchiveTest.java
+++ b/src/test/org/mbine/co/archive/ExtractArchiveTest.java
@@ -1,6 +1,5 @@
 package org.mbine.co.archive;
 
-import javafx.util.Pair;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.commons.io.FileUtils;
@@ -17,6 +16,7 @@ import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -90,7 +90,7 @@ public class ExtractArchiveTest {
       assertEquals(true, res);
       boolean hasMaster = archive.hasMasterFile();
       assertEquals(hasMasterFile, hasMaster);
-      Pair<String, InputStream> detectedMasterFile = archive.getMasterFile();
+      Map.Entry<String, InputStream> detectedMasterFile = archive.getMasterFile();
       String detectedFormat = detectedMasterFile.getKey();
       assertEquals(format, detectedFormat);
       InputStream stream = detectedMasterFile.getValue();


### PR DESCRIPTION
In OpenJDK 8, javax.util.Pair is not ported by default.

Discussed threads:
[1] https://gist.github.com/androidfred/bc64da9e6a355b984d37439ed63ae16b
[2] https://stackoverflow.com/q/16868446/865603