### PR TITLE
Hotfix/ncdfe u character

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,17 @@
             <artifactId>jena</artifactId>
             <version>2.6.4</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.ibm.icu</groupId>
+                    <artifactId>icu4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+            <version>4.8.1</version>
         </dependency>
         <dependency>
             <groupId>com.hp.hpl.jena</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.mbine.co</groupId>
     <artifactId>libCombineArchive</artifactId>
-    <version>0.2.2</version>
+    <version>0.3-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>


### PR DESCRIPTION
The work fixed the following bug:
```
|  java.lang.NoClassDefFoundError: com/ibm/icu/text/StringPrepParseException
	at com.hp.hpl.jena.iri.impl.SchemeSpecification.<init>(SchemeSpecification.java:55)
	at com.hp.hpl.jena.iri.ViolationCodes$Initialize.<clinit>(ViolationCodes.java:1360)
	at com.hp.hpl.jena.iri.IRIFactory.<clinit>(IRIFactory.java:98)
	at com.hp.hpl.jena.xmloutput.impl.BaseXMLWriter.<clinit>(BaseXMLWriter.java:491)
	at java.lang.Class.forName(Class.java:264)
	at com.hp.hpl.jena.rdf.model.impl.RDFWriterFImpl.getWriter(RDFWriterFImpl.java:122)
	at com.hp.hpl.jena.rdf.model.impl.RDFWriterFImpl.getWriter(RDFWriterFImpl.java:107)
	at com.hp.hpl.jena.rdf.model.impl.ModelCom.getWriter(ModelCom.java:235)
	at com.hp.hpl.jena.rdf.model.impl.ModelCom.write(ModelCom.java:271)
	at org.mbine.co.archive.CombineArchiveFactory.createMetadata(CombineArchiveFactory.java:97)
	at org.mbine.co.archive.CombineArchiveFactory.openArchive(CombineArchiveFactory.java:72)
	at net.biomodels.jummp.plugins.omex.OmexService.createCombineArchive(OmexService.groovy:200)
	at net.biomodels.jummp.plugins.omex.OmexServiceTests.testCreateCombineArchive(OmexServiceTests.groovy:121)
Caused by: java.lang.ClassNotFoundException: com.ibm.icu.text.StringPrepParseException
	at org.codehaus.groovy.tools.RootLoader.findClass(RootLoader.java:179)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at org.codehaus.groovy.tools.RootLoader.loadClass(RootLoader.java:151)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 13 more
```